### PR TITLE
change deprecated mesontest to the supported two words

### DIFF
--- a/configure
+++ b/configure
@@ -78,7 +78,6 @@ echooption() {
 }
 
 sanitycheck MESON 'meson'
-sanitycheck MESONTEST 'mesontest'
 sanitycheck NINJA 'ninja' 'ninja-build'
 
 declare -A default_options=(
@@ -143,7 +142,7 @@ install:
 	DESTDIR="\$(DESTDIR)" ${NINJA} ${NINJA_OPT} install
 
 check:
-	${MESONTEST} ${NINJA_OPT}
+	${MESON} test ${NINJA_OPT}
 END
 
 echo "


### PR DESCRIPTION
since 'mesontest' had been deprecated in 0.42 onwards,
we should change to use  'meson test' instead.

Signed-off-by: Tan Shen Joon <shen.joon.tan@intel.com>